### PR TITLE
info.xml `requires` tag is wrong format

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -17,7 +17,9 @@
   <releaseDate>2019-09-02</releaseDate>
   <version>1.1</version>
   <develStage>stable</develStage>
-  <requires>afform</requires>
+  <requires>
+    <ext>org.civicrm.afform</ext>
+  </requires>
   <compatibility>
     <ver>5.18</ver>
   </compatibility>


### PR DESCRIPTION
Hi,
The requires tag needs to have afform listed as a child element and needs the fully-qualified name i.e. <ext>org.civicrm.afform</ext>.
It can't currently be installed even if you have afform installed since it gives a fatal error and then on the next screen this points out the clue:
`Warning: array_merge(): Argument #2 is not an array in CRM_Extension_Manager->findInstallRequirements() (line 682 of .../sites/all/modules/civicrm/CRM/Extension/Manager.php)`.